### PR TITLE
Update Accepting AI card description to reflect 5-phase narrative

### DIFF
--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -7,6 +7,14 @@ import thisIsMe from "@/assets/this-is-me.jpg";
 const Portfolio = () => {
   const implementedPrototypes = [
     {
+      title: "Accepting AI: A Testing Adventure",
+      description:
+        "Ready to embrace AI as an AI Builder? Follow Acme Widget Co's journey from idea to production through 5 educational phases: Interview & Requirements → Solution Design → Implementation → Pre-Production Evaluation → Production Monitoring. Learn where AI evals fit in your testing pyramid alongside unit, integration, and E2E tests. Explore grounding checks, hallucination detection, and behavioral evals. Watch a real support chatbot evolve from verbose to hallucinating to reliably accurate—with full governance tracking. Your testing pyramid just got a shiny new AI-powered top!",
+      link: "/ai-evals/",
+      tags: ["Accepting AI", "Testing Pyramid", "Evals", "SDLC", "Governance"],
+      status: "Live Demo Available",
+    },
+    {
       title: "Your Learning Adventure Map",
       description:
         "Ready to level up as a team? Set shared goals, share your personal growth dreams, and let AI be your career compass! Inspired by Final Fantasy X's Skill Sphere Grid, this interactive map helps you discover the perfect next skills to master, connects you with ideal mentors, and shows you who you could guide. It's like having a career GPS that knows where your team wants to go AND where your heart wants to grow. Adventure awaits!",


### PR DESCRIPTION
Adding narrative for ai-evals prototype

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates portfolio UI content only by adding a new prototype card and description text, with no logic, data, or security-sensitive changes.
> 
> **Overview**
> Adds a new **"Accepting AI: A Testing Adventure"** entry to the `Live Prototypes` list in `Portfolio.tsx`, including a detailed 5-phase SDLC/testing narrative, `tags`, and a link to `\/ai-evals\/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 129ee774adc5bbf98cca1131ecd7c5d61ba80365. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->