### PR TITLE
fix: scroll to top on route navigation

### DIFF
--- a/apps/ai-builders-portal/src/layouts/PortalLayout.tsx
+++ b/apps/ai-builders-portal/src/layouts/PortalLayout.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Outlet, Link, useLocation } from "react-router-dom";
 import { GALAXY_BG_URL } from "@/design-system/tokens";
 
@@ -11,6 +12,10 @@ const navItems = [
 
 export default function PortalLayout() {
   const location = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location.pathname]);
 
   const isActive = (path: string) =>
     path === "/" ? location.pathname === "/" : location.pathname.startsWith(path);


### PR DESCRIPTION
## Summary
- Add scroll-to-top on route change in PortalLayout so pages like Challenge detail and Showcase load at the top on mobile

## Test plan
- [ ] Navigate to a challenge detail page on mobile — should start at top with challenge definition visible
- [ ] Navigate to showcase page — should start at top

🤖 Generated with [Claude Code](https://claude.com/claude-code)