### PR TITLE
fix: workshop run buttons not rendering output

### DIFF
--- a/apps/ai-evals-in-context/ai-testing-resource/templates/components/code_canvas.html
+++ b/apps/ai-evals-in-context/ai-testing-resource/templates/components/code_canvas.html
@@ -2,7 +2,7 @@
 <div class="code-canvas {% if secondary %}code-canvas--secondary{% endif %}{% if dark %} code-canvas--dark{% endif %}"
      {% if test_id %}data-test-id="{{ test_id }}"{% endif %}
      {% if file_path %}data-file="{{ file_path }}"{% endif %}
-     {% if mock_output %}data-mock-output="{{ mock_output | e }}"{% endif %}>
+     {% if mock_output %}data-mock-output='{{ mock_output }}'{% endif %}>
   <div class="code-canvas__header">
     <span class="code-canvas__filename">{{ filename }}</span>
     <div style="display: flex; align-items: center; gap: 0.5rem;">


### PR DESCRIPTION
## Summary
- Fix broken Run buttons in AI Evals workshop notebook cells
- Root cause: `| tojson` marks output as safe Markup, so `| e` was a no-op — raw `"` in JSON broke the double-quoted `data-mock-output` attribute
- Fix: use single-quoted attribute since `tojson` already escapes `'` as `\u0027`

## Test plan
- [ ] Click Run on rag_pipeline cell in workshop/1 — should show typewriter output
- [ ] Click Run on contrived_failure cell — should show computing spinner then metrics table
- [ ] Verify all 5 workshop stages have working Run buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)