### PR TITLE
fix(research-workspace): mobile responsiveness and vault routing

### DIFF
--- a/apps/research-workspace/Dockerfile
+++ b/apps/research-workspace/Dockerfile
@@ -5,6 +5,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     python3 \
     curl \
+    ca-certificates \
+    unzip \
     jq \
     git \
     && rm -rf /var/lib/apt/lists/*
@@ -19,9 +21,8 @@ RUN curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o /t
 # Create workspace directory (EFS mount point)
 RUN mkdir -p /workspace
 
-# Create non-root user
-RUN groupadd -g 1000 coder && useradd -u 1000 -g coder -m coder
-RUN chown coder:coder /workspace
+# Use existing node user (uid/gid 1000 in node:20-slim)
+RUN chown node:node /workspace
 
 # App directory
 WORKDIR /app
@@ -32,10 +33,10 @@ COPY src/ src/
 
 # Bake in a vault README
 COPY vault-readme.md /workspace/README.md
-RUN chown coder:coder /workspace/README.md
+RUN chown node:node /workspace/README.md
 
 # Run as non-root user
-USER coder
+USER node
 
 ENV PORT=8080
 ENV VAULT_ROOT=/workspace

--- a/prototypes/research-workspace/src/components/layout/WorkspaceLayout.tsx
+++ b/prototypes/research-workspace/src/components/layout/WorkspaceLayout.tsx
@@ -7,7 +7,14 @@ import {
 import FileBrowser from "../file-browser/FileBrowser";
 import MarkdownEditor from "../editor/MarkdownEditor";
 import TerminalPanel from "../terminal/TerminalPanel";
-import { FileText } from "lucide-react";
+import {
+  FileText,
+  FolderOpen,
+  Terminal as TerminalIcon,
+} from "lucide-react";
+import { useIsMobile } from "../../hooks/useIsMobile";
+
+type MobileTab = "files" | "editor" | "terminal";
 
 function ResizeHandle({
   direction = "horizontal",
@@ -49,14 +56,71 @@ function WelcomeScreen() {
 
 export default function WorkspaceLayout() {
   const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const [mobileTab, setMobileTab] = useState<MobileTab>("files");
+  const isMobile = useIsMobile();
 
   const handleSelectFile = useCallback((path: string) => {
     setSelectedFile(path);
   }, []);
 
+  const handleMobileSelectFile = useCallback((path: string) => {
+    setSelectedFile(path);
+    setMobileTab("editor");
+  }, []);
+
   const handleSave = useCallback(() => {
     // Could trigger tree refetch if needed
   }, []);
+
+  if (isMobile) {
+    const TABS: { id: MobileTab; icon: typeof FolderOpen; label: string }[] = [
+      { id: "files", icon: FolderOpen, label: "Files" },
+      { id: "editor", icon: FileText, label: "Editor" },
+      { id: "terminal", icon: TerminalIcon, label: "Terminal" },
+    ];
+
+    return (
+      <div className="workspace-layout h-screen bg-surface-container-lowest overflow-hidden flex flex-col">
+        {/* All panels stay mounted to preserve state and connections */}
+        <div className="flex-1 overflow-hidden relative">
+          <div className={`absolute inset-0 ${mobileTab === "files" ? "" : "hidden"}`}>
+            <FileBrowser
+              onSelectFile={handleMobileSelectFile}
+              selectedFile={selectedFile}
+            />
+          </div>
+          <div className={`absolute inset-0 ${mobileTab === "editor" ? "" : "hidden"}`}>
+            {selectedFile ? (
+              <MarkdownEditor filePath={selectedFile} onSave={handleSave} />
+            ) : (
+              <WelcomeScreen />
+            )}
+          </div>
+          <div className={`absolute inset-0 ${mobileTab === "terminal" ? "" : "hidden"}`}>
+            <TerminalPanel />
+          </div>
+        </div>
+
+        {/* Bottom tab bar */}
+        <div className="flex border-t border-outline-variant/20 bg-surface-container-low">
+          {TABS.map(({ id, icon: Icon, label }) => (
+            <button
+              key={id}
+              onClick={() => setMobileTab(id)}
+              className={`flex-1 flex flex-col items-center gap-1 py-3 text-xs font-label transition-colors ${
+                mobileTab === id
+                  ? "text-primary bg-primary/10"
+                  : "text-on-surface-variant/60"
+              }`}
+            >
+              <Icon className="w-5 h-5" />
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="workspace-layout h-screen bg-surface-container-lowest overflow-hidden">

--- a/prototypes/research-workspace/src/hooks/useIsMobile.ts
+++ b/prototypes/research-workspace/src/hooks/useIsMobile.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from "react";
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState<boolean | undefined>(undefined);
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    };
+    mql.addEventListener("change", onChange);
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+
+  return !!isMobile;
+}

--- a/prototypes/research-workspace/src/pages/GalleryPage.tsx
+++ b/prototypes/research-workspace/src/pages/GalleryPage.tsx
@@ -58,7 +58,7 @@ export default function GalleryPage() {
       {/* Header */}
       <header className="border-b border-outline-variant/30 bg-surface-container-low/50 backdrop-blur-md sticky top-0 z-10">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 py-4 sm:py-6">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4">
             <div>
               <h1 className="font-headline text-2xl sm:text-3xl font-bold text-on-surface">
                 Research Workspace
@@ -67,7 +67,7 @@ export default function GalleryPage() {
                 Insights, syntheses &amp; architecture diagrams connecting inference engineering to distributed systems, music &amp; architecture
               </p>
             </div>
-            <div className="hidden sm:flex items-center gap-4">
+            <div className="flex items-center gap-4">
               <a
                 href="/prototypes/research-workspace/vault/"
                 className="inline-flex items-center gap-1.5 font-label text-sm text-tertiary hover:text-tertiary/80 transition-colors"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -466,9 +466,9 @@ resource "aws_cloudfront_distribution" "website" {
   }
 
   # Research Workspace vault — authenticated via ALB/Cognito
-  # Full path passes through to ALB (no rewriting) — code-server handles all paths
+  # Full path passes through to ALB (no rewriting) — Express backend handles all vault paths
   ordered_cache_behavior {
-    path_pattern           = "/prototypes/research-workspace/vault/*"
+    path_pattern           = "/prototypes/research-workspace/vault*"
     allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods         = ["GET", "HEAD"]
     target_origin_id       = "ai-evals-api"

--- a/terraform/modules/research-workspace/main.tf
+++ b/terraform/modules/research-workspace/main.tf
@@ -3,8 +3,8 @@
 
 locals {
   application_root  = "/prototypes/research-workspace/vault"
-  # code-server runs at root / — CloudFront Function strips the vault path prefix
-  health_check_path = "/"
+  # Express backend serves /healthz
+  health_check_path = "/healthz"
 }
 
 # --- ECR Repository ---
@@ -218,19 +218,19 @@ resource "aws_ecs_task_definition" "main" {
       mountPoints = [
         {
           sourceVolume  = "vault-storage"
-          containerPath = "/home/coder/vault"
+          containerPath = "/workspace"
           readOnly      = false
         }
       ]
 
       environment = [
         {
-          name  = "CODER_BASE_PATH"
-          value = "/prototypes/research-workspace/vault"
+          name  = "VAULT_ROOT"
+          value = "/workspace"
         },
         {
-          name  = "PASSWORD"
-          value = ""
+          name  = "PORT"
+          value = tostring(var.container_port)
         }
       ]
 
@@ -244,7 +244,7 @@ resource "aws_ecs_task_definition" "main" {
       }
 
       healthCheck = {
-        command     = ["CMD-SHELL", "curl -sf http://localhost:${var.container_port}/ || exit 1"]
+        command     = ["CMD-SHELL", "curl -sf http://localhost:${var.container_port}/healthz || exit 1"]
         interval    = 30
         timeout     = 10
         retries     = 3


### PR DESCRIPTION
## Summary

- **Fix vault 404**: CloudFront `path_pattern` changed from `vault/*` to `vault*` — the old pattern didn't match `/vault` without a trailing slash, causing requests to fall through to the S3 gallery behavior instead of routing to ALB/Cognito
- **Fix mobile sign-in button**: Gallery header restructured from `hidden sm:flex` to `flex-col sm:flex-row` so "Sign in to publish" and Portfolio links are visible on all screen sizes
- **Add mobile workspace layout**: Below 768px, the 3-panel resizable layout is replaced with a bottom tab bar (Files / Editor / Terminal). All panels stay mounted via CSS `hidden` to preserve WebSocket connections and editor state. Selecting a file auto-switches to the Editor tab
- **Pre-existing worktree changes**: Dockerfile user fix (coder→node), Terraform health check path (`/` → `/healthz`), container mount path and env vars updated for Express backend

## Test plan

- [ ] `terraform plan` — verify CloudFront behavior path_pattern change is clean
- [ ] Visit `/prototypes/research-workspace/vault` (no trailing slash) — should route to Cognito auth, not gallery
- [ ] Mobile viewport on gallery page — "Sign in to publish" and "Portfolio" links visible below header title
- [ ] Mobile viewport on `/workspace` — bottom tab bar with Files/Editor/Terminal; tapping file switches to Editor
- [ ] Desktop viewport — gallery header and workspace panels unchanged
- [ ] `yarn workspace @proto-portal/research-workspace build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)