### PR TITLE
chore: remove GitNexus, homepage redesign, scale-to-zero backend, AWS cost model

### DIFF
--- a/.claude/hooks/guard-secrets.sh
+++ b/.claude/hooks/guard-secrets.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# guard-secrets.sh — PreToolUse hook (Bash matcher).
+#
+# Blocks shell commands that would print live credentials to stdout, where they
+# get captured into agent transcripts (~/.claude/projects/**/*.jsonl), shell
+# history, and debug logs. This is the recurrence guard for the credential leak
+# found in the local Claude logs (AWS keys, sk-ant keys, GitHub PAT).
+#
+# The approved pattern is a named AWS CLI profile (AWS_PROFILE=deploy), which
+# assumes the role automatically WITHOUT ever materializing secret values in
+# command output. See CLAUDE.md → "IAM Role" and terraform/AGENTS.md §3.
+#
+# Contract: read hook JSON on stdin. Exit 0 = allow. Exit 2 = block (stderr is
+# shown to the model). Any other failure mode fails OPEN (exit 0) so a broken
+# hook never wedges the session.
+set -uo pipefail
+
+input="$(cat)"
+
+# Extract the Bash command string from the hook payload (fail open if we can't).
+cmd="$(printf '%s' "$input" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+if d.get("tool_name") != "Bash":
+    sys.exit(0)
+print(d.get("tool_input", {}).get("command", ""))
+' 2>/dev/null)" || exit 0
+
+[ -z "$cmd" ] && exit 0
+
+block() {
+  echo "BLOCKED by guard-secrets hook: $1" >&2
+  echo "" >&2
+  echo "This command would write live credential values to stdout, which get captured into" >&2
+  echo "agent transcripts and shell history. Use a named AWS CLI profile instead — it assumes" >&2
+  echo "the role automatically with NO secret values in any output:" >&2
+  echo "    aws configure set role_arn <ROLE_ARN> --profile deploy" >&2
+  echo "    aws configure set source_profile default --profile deploy   # or: credential_source Environment" >&2
+  echo "    export AWS_PROFILE=deploy" >&2
+  echo "See CLAUDE.md → 'IAM Role' and terraform/AGENTS.md §3." >&2
+  exit 2
+}
+
+# 1. The classic leak: assume-role piped into a print of export AWS_SECRET...
+if printf '%s' "$cmd" | grep -Eq 'assume-role' \
+   && printf '%s' "$cmd" | grep -Eiq 'print.*(SecretAccessKey|AWS_SECRET_ACCESS_KEY|export AWS_)'; then
+  block "assume-role output is being printed as 'export AWS_...' (credential leak to stdout)."
+fi
+
+# 2. Assigning the secret to a literal or command substitution (not via profile).
+#    Allowed: referencing it ($AWS_SECRET_ACCESS_KEY) or unsetting it.
+if printf '%s' "$cmd" | grep -Eq 'export[[:space:]]+AWS_SECRET_ACCESS_KEY=[^[:space:]$]' \
+   || printf '%s' "$cmd" | grep -Eq 'export[[:space:]]+AWS_SECRET_ACCESS_KEY=\$\('; then
+  block "exporting a raw AWS_SECRET_ACCESS_KEY value — use AWS_PROFILE instead."
+fi
+
+# 3. Echoing/printing a known credential variable's value.
+if printf '%s' "$cmd" | grep -Eiq '(echo|printf|print)[^|;&]*\$\{?(AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN|ANTHROPIC_API_KEY|CLAUDE_API_KEY|GH_TOKEN|GITHUB_TOKEN|CREDS)\b'; then
+  block "echoing a credential variable's value to stdout."
+fi
+
+# 4. Reading known secret-bearing files (would dump their contents into the transcript).
+if printf '%s' "$cmd" | grep -Eq '(cat|less|more|bat|head|tail|nl|xxd|od)[[:space:]][^|;&]*(secrets\.env|z_creds/|\.pem\b|/\.aws/credentials|aws/credentials)'; then
+  block "reading a secret-bearing file (secrets.env / z_creds/ / *.pem / ~/.aws/credentials) into stdout."
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/guard-secrets.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,8 @@ GitHub Actions (`.github/workflows/deploy.yml`) runs on push to `main`:
 
 See `terraform/AGENTS.md` for detailed infrastructure guidance.
 
+**Cost discipline:** the expected AWS spend model lives in [`billing.md`](billing.md) (~$30/mo idle, scale-to-zero architecture). Any change to deployed infrastructure must update that file — the checklist is in `terraform/AGENTS.md` → "Cost Impact of Changes".
+
 Key resources: S3 (static hosting), CloudFront (CDN + SPA routing), Lambda (API), API Gateway, Route53 (DNS), Secrets Manager.
 
 State stored in S3 with DynamoDB locking.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ aws sts get-caller-identity          # verifies; the CLI assumes the role under 
 
 **ARM64:** ECS uses Graviton. Do NOT add `--platform linux/amd64` to Docker builds. CI uses ARM64 runners.
 
+**Cost model:** `billing.md` tracks expected AWS spend (~$30/mo idle, scale-to-zero). Every infrastructure change MUST update it — see `terraform/AGENTS.md` → "Cost Impact of Changes".
+
 ## Git Commits
 
 - Conventional prefixes: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`

--- a/billing.md
+++ b/billing.md
@@ -1,0 +1,88 @@
+# AWS Billing & Cost Model
+
+> **Standing rule:** any change to deployed infrastructure (terraform/, deploy scripts, ECS/Lambda config) must update this file's expected-cost model and the "Update log" below. See `terraform/AGENTS.md` → "Cost Impact of Changes".
+
+Account: `671388079324` · Region: `us-east-1` · Budget guardrail: AWS Budget `research-workspace-monthly` at **$100/mo** with 50/80/100% alerts.
+
+Last reconciled against Cost Explorer: **2026-07-03** (data through 2026-07-02).
+
+---
+
+## Current expected steady-state: ~$29–31/month
+
+After the 2026-06-28 changes (AI Evals hosted demo retired, Research Workspace scaled to zero, RDS deleted), the observed run rate is **~$0.90/day**. Verified live: ECS `desiredCount=0`, zero RDS instances, no NAT gateways, no EC2.
+
+| Line item | $/mo | Nature | Notes |
+|---|---|---|---|
+| ALB `ai-testing-resource-prod` | 16.60 | **Always-on** | $0.0225/hr + minimal LCU. Fronts only the scale-to-zero Research Workspace. |
+| Public IPv4 ×2 (the ALB's own IPs) | 7.30 | **Always-on** | $0.005/hr each. Goes away only if the ALB does. |
+| Secrets Manager (8 secrets) | 3.20 | Always-on | $0.40/secret/mo |
+| Route53 hosted zones + queries | 1.55 | Always-on | |
+| S3 (site bucket + tf state) | 0.50 | Grows slowly | Versioning ON with **no lifecycle rule** — 12.5k old versions and counting |
+| ECR (research-workspace image) | 0.15 | Always-on | Lifecycle keeps last 5 images |
+| DynamoDB / EFS / CloudWatch / SNS | ~0.15 | On-demand | DynamoDB PITR is the only standing piece; all log groups have 14–30d retention |
+| CloudFront / Lambda / API GW / Cognito | ~0.00 | On-demand | Within free tier at portfolio traffic levels |
+| Tax (~9–10%) | ~2.60 | | |
+| **Total** | **~$30** | | Plus **$15/yr** domain renewal (hit June 2026) |
+
+**The ALB + its two IPs = ~$24/mo, i.e. ~80% of idle spend.** Everything else is single dollars.
+
+## Usage-driven costs (what varies)
+
+- **Research Workspace wake events**: Fargate ARM 0.5 vCPU / 1 GB ≈ **$0.02/hr on-demand, ~$0.006/hr on Spot** (capacity strategy prefers Spot 4:1). Reaper (EventBridge every 5 min) scales back to 0 on stale heartbeat; nightly 07:00 UTC cron is the backstop. Even 100 hrs/mo of use adds only **$1–2**.
+- **CloudFront traffic**: free tier covers 1 TB + 10M requests/mo. A viral day (~100k visits × ~3 MB) stays inside it. Beyond: $0.085/GB.
+- **AI API Lambda / OIDC proxy Lambda**: free tier covers realistic volumes; the 5-min reaper (~8,640 invokes/mo × 128 MB × <1s) is also free-tier.
+
+## Scenarios
+
+| Scenario | Expected monthly total |
+|---|---|
+| Idle (nobody uses anything) | **~$30** |
+| Normal — portfolio browsing + ~10 hrs workspace use | **~$30** |
+| Heavy — 160 hrs/mo workspace use | **~$33** |
+| **Failure mode** — reaper broken, 1 task pinned 24/7 | **~$45** (watch for ECS ≥ $0.50/day when you aren't using it) |
+| Pre-June-28 architecture (for reference) | ~$85–90 |
+| Hard ceiling | $100 budget alert |
+
+## What actually happened (Cost Explorer, reconciled 2026-07-03)
+
+Monthly totals: **Mar $56 → Apr $86 → May $79 → Jun $89 → Jul running at ~$0.90/day (~$29/mo pace)**.
+
+The Apr–Jun elevation you saw was real and is **already fixed**:
+- **ECS $27–31/mo**: exactly two always-on Fargate task-equivalents — the AI Evals Flask demo *plus* the Research Workspace backend, both 24/7. Daily ECS was a flat $0.95/day through June 28, then $0 from June 29 onward (scale-to-zero deploy).
+- **RDS $13–14/mo**: the AI Evals Postgres (db.t4g.micro + 20 GB gp3). $0 from June 29 (deleted).
+- **June also carried the one-time $15 domain renewal** (Amazon Registrar), inflating that month.
+- ALB ($0.54/day), IPv4 ($0.24/day after one IP was released with the retirement), Secrets, Route53 continue unchanged — they are the current baseline.
+
+Daily total went **$2.45/day → $0.90/day on June 29**. If a future bill looks high, the first check is `ECS > $0` on days you didn't use the workspace (reaper failure).
+
+## Cost-reduction levers (not yet taken)
+
+1. **Replace the ALB** (~$24/mo → biggest lever by far). It exists only for Research Workspace routing + Cognito ALB-auth + the Lambda scaler target. Moving to CloudFront → Lambda Function URL / API Gateway would cut idle cost to ~$6–7/mo, but requires reworking auth and code-server WebSocket routing. Worth it only if $24/mo matters.
+2. **S3 lifecycle rule** for noncurrent versions (e.g. expire after 30 days). Costs ~$0.50/mo today but grows unbounded with every deploy.
+3. **Consolidate Secrets Manager secrets** — the 6 `research-workspace-prod/*` values could live in 1–2 JSON secrets: saves ~$2/mo.
+4. **CloudFront `price_class`** is unset → PriceClass_All. Set `PriceClass_100` (NA+EU) if non-free-tier traffic ever materializes; $0 impact today.
+
+## How to reconcile (repeat this when checking)
+
+```bash
+export AWS_PROFILE=deploy
+# Monthly by service
+aws ce get-cost-and-usage --time-period Start=<YYYY-MM-01>,End=<today> \
+  --granularity MONTHLY --metrics UnblendedCost --group-by Type=DIMENSION,Key=SERVICE
+# Daily for spotting when something changed
+aws ce get-cost-and-usage --time-period Start=<30d-ago>,End=<today> \
+  --granularity DAILY --metrics UnblendedCost --group-by Type=DIMENSION,Key=SERVICE
+# Usage-type decomposition (what inside a service is billing)
+aws ce get-cost-and-usage --time-period Start=<month>,End=<month-end> \
+  --granularity MONTHLY --metrics UnblendedCost --group-by Type=DIMENSION,Key=USAGE_TYPE
+```
+
+Cost Explorer access is granted via inline policy `cost-explorer-readonly` on role `terraform-cooking-up-ideas` (read-only `ce:Get*`, added 2026-07-03).
+
+## Update log
+
+| Date | Change | Expected impact |
+|---|---|---|
+| 2026-07-03 | Initial cost model; reconciled vs Cost Explorer Mar–Jul. Added `cost-explorer-readonly` inline policy to deploy role. | Baseline ~$30/mo idle |
+| 2026-06-28 | (retroactive) AI Evals demo retired: ECS service, RDS, API GW origin removed. Research Workspace scale-to-zero with wake-on-request + 5-min reaper. | −$55/mo (from ~$85 to ~$30) — confirmed in daily data |

--- a/terraform/AGENTS.md
+++ b/terraform/AGENTS.md
@@ -137,6 +137,17 @@ A complete ECS container deployment requires ALL of these steps:
 2. For destructive changes (resource replacement), confirm with the user
 3. After modifying CloudFront config, remember it takes ~5 minutes to propagate globally
 4. After adding/removing a prototype, update the CloudFront function's prototype list
+5. **Update the cost model** — see "Cost Impact of Changes" below
+
+## Cost Impact of Changes (MANDATORY)
+
+Whenever you add, remove, resize, or reschedule any deployed resource — Terraform, ECS task sizing, Lambda schedules, desired counts, log retention, anything that bills — you MUST:
+
+1. Estimate the monthly cost delta of the change before applying it (state it to the user).
+2. Update [`/billing.md`](../billing.md): adjust the expected steady-state table / scenarios and append a row to its **Update log** with date, change, and expected impact.
+3. If the change is meant to reduce cost, reconcile against Cost Explorer a few days later (commands are in `billing.md`) to confirm the daily rate actually moved.
+
+Rules of thumb for this account: the target idle run rate is **~$0.90/day (~$30/mo)**; the dominant fixed cost is the ALB + its 2 public IPv4s (~$24/mo). Anything always-on (NAT gateway, RDS, `desired_count >= 1` Fargate, ALB/NLB, EIP, provisioned capacity) needs explicit justification — the architecture here is deliberately scale-to-zero.
 
 ## Related
 


### PR DESCRIPTION
Consolidates the current working branch into main. Contains seven commits:

- **chore(infra):** AWS cost model (`billing.md`) + secret-leak guard hook
- **feat(portfolio):** homepage redesigned as single-screen hero overlay
- **perf(portfolio):** eliminate black flash on hero video load
- **chore(ai-evals):** retire hosted demo, reframe as eval-trace workspace
- **fix(research-workspace):** wake backend before sign-in to avoid 503
- **feat(research-workspace):** scale ECS backend to zero with wake-on-request
- **feat(research-workspace):** GitHub-style vault search bar
- **chore:** remove GitNexus integration and benchmark prototype

## Cost impact
Infra changes here (scale-to-zero + AI Evals retirement) drop idle AWS spend from ~$85/mo to ~$30/mo. Model tracked in `billing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)