### PR TITLE
chore: untrack stray Claude worktree gitlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ apps/ai-evals-in-context/ai-testing-resource/static/vendor/
 
 # Local credential bootstrap workspace — never commit
 z_creds/
+
+# Local Claude Code worktrees (never commit these)
+.claude/worktrees/


### PR DESCRIPTION
Removes an accidentally-committed git worktree gitlink (`.claude/worktrees/zen-cerf-bc4d6b`, introduced in "add the algo visualizer") from the tracked tree and gitignores `.claude/worktrees/` so local worktrees never land in the repo again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)